### PR TITLE
support python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='ip3country',
-    version='0.1.0',
+    version='0.2.0',
     url='https://github.com/statsig-io/ip3country-py',
     author='Statsig',
     author_email='tore@statsig.com',
@@ -20,5 +20,5 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
     ],
     include_package_data=True,
-    python_requires='>=3.0',
+    python_requires='>=2.0',
 )


### PR DESCRIPTION
On python 2.7

Before:

```
ERROR: Could not find a version that satisfies the requirement ip3country (from versions: none)
ERROR: No matching distribution found for ip3country
```

After:

```
Successfully built ip3country
Installing collected packages: ip3country
```