### PR TITLE
Make CountryLookup threadsafe by eliminating global state and memory leak when constructor is called multiple times

### DIFF
--- a/ip3country/country_lookup.py
+++ b/ip3country/country_lookup.py
@@ -1,11 +1,10 @@
 import os
 
 class CountryLookup:
-    countryCodes = []
-    countryTable = []
-    ipRanges = []
-
     def __init__(self):
+        self.countryCodes = []
+        self.countryTable = []
+        self.ipRanges = []
         datafile = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data', 'ip_supalite.table')
         with open(datafile, mode="rb") as file:
             self.ipSupalite = file.read()


### PR DESCRIPTION
The class variables are appended to on each initialization causing them to grow in size on each initialization. This can cause a memory leak and thread safety issues. This change makes it so that all the state is per-instance.


fixes: #7 
fixes: #8